### PR TITLE
Fixes adjustments updater to skip update if adjustable was destroyed

### DIFF
--- a/app/models/spree/adjustable/adjustments_updater_decorator.rb
+++ b/app/models/spree/adjustable/adjustments_updater_decorator.rb
@@ -11,7 +11,7 @@ Spree::Adjustable::AdjustmentsUpdater.class_eval do
         handling_total: handling_total,
         adjustment_total: adjustable.adjustment_total + handling_total,
         updated_at: Time.now
-      )
+      ) unless adjustable.destroyed?
     end
   end
 


### PR DESCRIPTION
Found this bug when working on Spree API. Deleting a line item from an order would cause a `cannot update a destroyed record` error.
